### PR TITLE
Swap implode parameters

### DIFF
--- a/src/OAuth/Services/OAuthService.php
+++ b/src/OAuth/Services/OAuthService.php
@@ -185,7 +185,7 @@ class OAuthService
             'redirect_uri'  => $this->getConfig('ruName'),
             'response_type' => 'code',
             'state'         => $params['state'],
-            'scope'         => implode($params['scope'], ' ')
+            'scope'         => implode(' ', $params['scope'])
 
         ];
 


### PR DESCRIPTION
Fix PHP 7.4 "Passing glue string after array is deprecated. Swap the parameters"